### PR TITLE
Add Backlink to main site

### DIFF
--- a/src/mkdocs.yml
+++ b/src/mkdocs.yml
@@ -42,7 +42,8 @@ extra:
     
 
 nav:
-  - Home: index.md
+  - < Home: https://howtoopenscience.com
+  - Introduction: index.md
   - Background: background.md
   - Agenda: agenda.md
   - Supplemental Materials: supplemental.md


### PR DESCRIPTION
Changes the 'Home' link to point to the main site at `https://howtoopenscience.com` and adds the index under the introduction section.